### PR TITLE
redirect www to non-www to avoid content duplication in Google

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -24,6 +24,10 @@ server {
         if ($http_x_forwarded_proto = "http") {
             return 301 https://creatingvalue.co$request_uri;
         }
+        # www to non-www for https
+        if ($host ~ ^www\.(?<domain>.+)$) {
+            return  301 $scheme://$domain$request_uri;
+        }
         proxy_pass http://website.com:3000/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Using `curl -I https://www.creatingvalue.co` should return:

```
HTTP/1.1 301 Moved Permanently
Server: nginx/1.19.1
Date: Mon, 13 Jul 2020 11:16:00 GMT
Content-Type: text/html
Content-Length: 169
Location: https://creatingvalue.co/
Via: 1.1 google
```